### PR TITLE
Add check symbols script

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -280,7 +280,8 @@ jobs:
                   --skip-dir src/app/util \
                   --skip-dir zzz_generated/app-common/app-common/zap-generated \
                   --skip-dir src/app/zap-templates/templates \
-                  --skip-dir src/app/codegen-data-node-provider
+                  --skip-dir src/app/codegen-data-node-provider \
+                  --skip-dir src/data-model-providers
 
             # git grep exits with 0 if it finds a match, but we want
             # to fail (exit nonzero) on match.  And we want to exclude this file,

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -274,7 +274,6 @@ jobs:
                   Check for use of 'emberAf' or 'emAf' symbols
               if: always()
               run: |
-                  chmod +x scripts/check_symbols.sh
                   scripts/check_symbols.sh \
                   --skip-dir .github \
                   --skip-dir src/app/util \
@@ -282,6 +281,7 @@ jobs:
                   --skip-dir src/app/zap-templates/templates \
                   --skip-dir src/app/codegen-data-node-provider \
                   --skip-dir src/data-model-providers
+                  --skip-dir scripts/
 
             # git grep exits with 0 if it finds a match, but we want
             # to fail (exit nonzero) on match.  And we want to exclude this file,

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -271,15 +271,15 @@ jobs:
             # to avoid our grep regexp matching itself, as well as excluding the files
             # that implement the type-safe accessors
             - name:
-                  Check for use of 'emberAf' symbols
+                  Check for use of 'emberAf' or 'emAf' symbols
               if: always()
               run: |
                   chmod +x scripts/check_symbols.sh
                   scripts/check_symbols.sh \
                   --skip-dir .github \
                   --skip-dir src/app/util \
-                  --skip-dir zzz_generated/app-common/app-common/zap-generated/access/Accessors.h \
-                  --skip-dir src/app/zap-templates/templates/app/attributes/Accessors-src.zapt \
+                  --skip-dir zzz_generated/app-common/app-common/zap-generated \
+                  --skip-dir src/app/zap-templates/templates \
                   --skip-dir src/app/codegen-data-node-provider
 
             # git grep exits with 0 if it finds a match, but we want

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -274,13 +274,7 @@ jobs:
                   Check for use of 'emberAf' symbols
               if: always()
               run: |
-                  ./scripts/check_symbols.sh ':(exclude).github/*' ':(exclude)src/app/util/*' ':(exclude)zzz_generated/app-common/app-common/zap-generated/access/Accessors.h' ':(exclude)src/app/zap-templates/templates/app/attributes/Accessors-src.zapt'
-
-            - name:
-                  Check for use of 'emAf' symbols
-              if: always()
-              run: |
-                  ./scripts/check_symbols.sh ':(exclude).github/*' ':(exclude)src/app/util/*' ':(exclude)zzz_generated/app-common/app-common/zap-generated/access/Accessors.h' ':(exclude)src/app/zap-templates/templates/app/attributes/Accessors-src.zapt'
+                  ./scripts/check_symbols.sh --skip-dir .github --skip-dir src/app/util --skip-dir zzz_generated/app-common/app-common/zap-generated/access/Accessors.h --skip-dir src/app/zap-templates/templates/app/attributes/Accessors-src.zapt
 
             # git grep exits with 0 if it finds a match, but we want
             # to fail (exit nonzero) on match.  And we want to exclude this file,
@@ -334,8 +328,7 @@ jobs:
                   git grep -I -n 'SuccessOrExit([^=)]*(' -- './*' ':(exclude).github/workflows/lint.yml' && exit 1 || exit 0
 
             # git grep exits with 0 if it finds a match, but we want
-            # to fail (exit nonzero) on match.  And we want to exclude this file,
-            # to avoid our grep regexp matching itself.
+            # to fail (exit nonzero) on match.
             - name:
                   Check for use of "using namespace" outside of a class/function
                   in headers.

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -274,6 +274,7 @@ jobs:
                   Check for use of 'emberAf' or 'emAf' symbols
               if: always()
               run: |
+                  chmod +x scripts/check_symbols.sh
                   scripts/check_symbols.sh \
                   --skip-dir .github \
                   --skip-dir src/app/util \

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -274,7 +274,13 @@ jobs:
                   Check for use of 'emberAf' symbols
               if: always()
               run: |
-                  ./scripts/check_symbols.sh --skip-dir .github --skip-dir src/app/util --skip-dir zzz_generated/app-common/app-common/zap-generated/access/Accessors.h --skip-dir src/app/zap-templates/templates/app/attributes/Accessors-src.zapt
+                  chmod +x scripts/check_symbols.sh
+                  scripts/check_symbols.sh \
+                  --skip-dir .github \
+                  --skip-dir src/app/util \
+                  --skip-dir zzz_generated/app-common/app-common/zap-generated/access/Accessors.h \
+                  --skip-dir src/app/zap-templates/templates/app/attributes/Accessors-src.zapt \
+                  --skip-dir src/app/codegen-data-node-provider
 
             # git grep exits with 0 if it finds a match, but we want
             # to fail (exit nonzero) on match.  And we want to exclude this file,

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -274,30 +274,14 @@ jobs:
                   Check for use of 'emberAf' symbols
               if: always()
               run: |
-                  emberAf_matches=$(git grep -I -n '\<emberAf[A-Za-z0-9_]*' -- './*' \
-                    ':(exclude).github/*' \
-                    ':(exclude)src/app/util/*' \
-                    ':(exclude)zzz_generated/app-common/app-common/zap-generated/access/Accessors.h' \
-                    ':(exclude)src/app/zap-templates/templates/app/attributes/Accessors-src.zapt') \
-                    && echo "Error: Found 'emberAf' symbols in the following files and lines:" \
-                    && echo "$emberAf_matches" \
-                    && exit 1 || exit 0
+                  ./scripts/check_symbols.sh ':(exclude).github/*' ':(exclude)src/app/util/*' ':(exclude)zzz_generated/app-common/app-common/zap-generated/access/Accessors.h' ':(exclude)src/app/zap-templates/templates/app/attributes/Accessors-src.zapt'
 
-            # First pattern: emberAf
-            # ---
             - name:
                   Check for use of 'emAf' symbols
               if: always()
               run: |
-                  emAf_matches=$(git grep -I -n '\<emAf[A-Za-z0-9_]*' -- './*' \
-                    ':(exclude).github/*' \
-                    ':(exclude)src/app/util/*' \
-                    ':(exclude)zzz_generated/app-common/app-common/zap-generated/access/Accessors.h' \
-                    ':(exclude)src/app/zap-templates/templates/app/attributes/Accessors-src.zapt') \
-                    && echo "Error: Found 'emAf' symbols in the following files and lines:" \
-                    && echo "$emAf_matches" \
-                    && exit 1 || exit 0
-            # Second pattern: emAf
+                  ./scripts/check_symbols.sh ':(exclude).github/*' ':(exclude)src/app/util/*' ':(exclude)zzz_generated/app-common/app-common/zap-generated/access/Accessors.h' ':(exclude)src/app/zap-templates/templates/app/attributes/Accessors-src.zapt'
+
             # git grep exits with 0 if it finds a match, but we want
             # to fail (exit nonzero) on match.  And we want to exclude this file,
             # to avoid our grep regexp matching itself, as well as excluding the files
@@ -350,7 +334,8 @@ jobs:
                   git grep -I -n 'SuccessOrExit([^=)]*(' -- './*' ':(exclude).github/workflows/lint.yml' && exit 1 || exit 0
 
             # git grep exits with 0 if it finds a match, but we want
-            # to fail (exit nonzero) on match.
+            # to fail (exit nonzero) on match.  And we want to exclude this file,
+            # to avoid our grep regexp matching itself.
             - name:
                   Check for use of "using namespace" outside of a class/function
                   in headers.

--- a/scripts/check_symbols.sh
+++ b/scripts/check_symbols.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# This script checks for the use of 'ember' and 'emAf' symbols in the codebase.
+# It takes exclusion folders as arguments.
+
+# Function to check for 'ember' and 'emAf' symbols
+check_symbols() {
+    local exclusions=("$@")
+    local exclude_args=()
+    for exclude in "${exclusions[@]}"; do
+        exclude_args+=(":(exclude)$exclude")
+    done
+
+    ember_matches=$(git grep -I -n '\<ember[A-Za-z0-9_]*' -- './*' "${exclude_args[@]}" \
+        ':(exclude).github/*' \
+        ':(exclude)src/app/util/*' \
+        ':(exclude)zzz_generated/app-common/app-common/zap-generated/access/Accessors.h' \
+        ':(exclude)src/app/zap-templates/templates/app/attributes/Accessors-src.zapt')
+
+    emAf_matches=$(git grep -I -n '\<emAf[A-Za-z0-9_]*' -- './*' "${exclude_args[@]}" \
+        ':(exclude).github/*' \
+        ':(exclude)src/app/util/*' \
+        ':(exclude)zzz_generated/app-common/app-common/zap-generated/access/Accessors.h' \
+        ':(exclude)src/app/zap-templates/templates/app/attributes/Accessors-src.zapt')
+
+    if [[ -n "$ember_matches" || -n "$emAf_matches" ]]; then
+        echo "Error: Found 'ember' or 'emAf' symbols in the following files and lines:"
+        [[ -n "$ember_matches" ]] && echo "$ember_matches"
+        [[ -n "$emAf_matches" ]] && echo "$emAf_matches"
+        exit 1
+    fi
+}
+
+# Main script execution
+exclusions=("$@")
+check_symbols "${exclusions[@]}"

--- a/scripts/check_symbols.sh
+++ b/scripts/check_symbols.sh
@@ -5,19 +5,27 @@
 
 # Function to check for 'ember' and 'emAf' symbols
 check_symbols() {
-    local exclusions=("$@")
-    local exclude_args=()
-    for exclude in "${exclusions[@]}"; do
-        exclude_args+=(":(exclude)$exclude")
+    local exclusions=()
+    while [[ $# -gt 0 ]]; do
+        case $1 in
+            --skip-dir)
+                exclusions+=(":(exclude)$2")
+                shift 2
+                ;;
+            *)
+                echo "Unknown option: $1"
+                exit 1
+                ;;
+        esac
     done
 
-    ember_matches=$(git grep -I -n '\<ember[A-Za-z0-9_]*' -- './*' "${exclude_args[@]}" \
+    ember_matches=$(git grep -I -n '\<ember[A-Za-z0-9_]*' -- './*' "${exclusions[@]}" \
         ':(exclude).github/*' \
         ':(exclude)src/app/util/*' \
         ':(exclude)zzz_generated/app-common/app-common/zap-generated/access/Accessors.h' \
         ':(exclude)src/app/zap-templates/templates/app/attributes/Accessors-src.zapt')
 
-    emAf_matches=$(git grep -I -n '\<emAf[A-Za-z0-9_]*' -- './*' "${exclude_args[@]}" \
+    emAf_matches=$(git grep -I -n '\<emAf[A-Za-z0-9_]*' -- './*' "${exclusions[@]}" \
         ':(exclude).github/*' \
         ':(exclude)src/app/util/*' \
         ':(exclude)zzz_generated/app-common/app-common/zap-generated/access/Accessors.h' \
@@ -32,5 +40,4 @@ check_symbols() {
 }
 
 # Main script execution
-exclusions=("$@")
-check_symbols "${exclusions[@]}"
+check_symbols "$@"


### PR DESCRIPTION
Refactor the lint workflow to use a shell script for checking 'ember' and 'emAf' symbols.

* Add `scripts/check_symbols.sh` to check for 'ember' and 'emAf' symbols and take exclusion folders as arguments.
* Modify `.github/workflows/lint.yml` to remove the jobs "Check for use of 'ember' symbols" and "Check for use of 'emAf' symbols".
* Add a job in `.github/workflows/lint.yml` to call the shell script with the same exclusion folders.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/jennygaz/connectedhomeip/pull/2?shareId=22e06d8c-067f-4ef9-bb93-fdfe07d496a3).